### PR TITLE
Add required_value attribute to s2MOP shortcode.

### DIFF
--- a/s2member-pro/includes/classes/sc-mop-vars-notice-in.inc.php
+++ b/s2member-pro/includes/classes/sc-mop-vars-notice-in.inc.php
@@ -52,7 +52,7 @@ if(!class_exists('c_ws_plugin__s2member_pro_sc_mop_vars_notice_in'))
 			$valid_required_types    = array('level', 'ccap', 'sp');
 			$valid_seeking_types     = array('page', 'post', 'catg', 'ptag', 'file', 'ruri');
 			$valid_restriction_types = array('page', 'post', 'catg', 'ptag', 'file', 'ruri', 'ccap', 'sp', 'sys');
-			$attr                    = shortcode_atts(array('seeking_type' => '', 'required_type' => '', 'restriction_type' => ''), $attr, $shortcode);
+			$attr                    = shortcode_atts(array('seeking_type' => '', 'required_type' => '', 'required_value' => '', 'restriction_type' => ''), $attr, $shortcode);
 
 			# ---------------------------------------------------------------------------------------------------
 
@@ -63,19 +63,20 @@ if(!class_exists('c_ws_plugin__s2member_pro_sc_mop_vars_notice_in'))
 				$attr['required_value']   = array_unique(preg_split('/[|;,\s]+/', $attr['required_value'], NULL, PREG_SPLIT_NO_EMPTY));
 				$attr['restriction_type'] = array_unique(preg_split('/[|;,\s]+/', $attr['restriction_type'], NULL, PREG_SPLIT_NO_EMPTY));
 
-				if(isset($attr['seeking_type']) && array_intersect($attr['seeking_type'], $valid_seeking_types))
+				if(array_intersect($attr['seeking_type'], $valid_seeking_types))
 					if(empty($_g['_s2member_seeking']['type']) || !in_array($_g['_s2member_seeking']['type'], $attr['seeking_type'], TRUE))
 						return '';
 
-				if(isset($attr['required_type']) && array_intersect($attr['required_type'], $valid_required_types)) {
+				if(array_intersect($attr['required_type'], $valid_required_types)) {
 					if(empty($_g['_s2member_req']['type']) || !in_array($_g['_s2member_req']['type'], $attr['required_type'], TRUE))
 						return '';
 
-					if(isset($attr['required_value']) && ( count($attr['required_type']) !== 1 || !in_array($_g['_s2member_req'][$_g['_s2member_req']['type']], $attr['required_value'], TRUE)))
+					$required_type = $_g['_s2member_req']['type'];
+					if(count($attr['required_type']) !== 1 || !in_array($_g['_s2member_req'][$required_type], $attr['required_value'], TRUE))
 						return '';
 				}
 
-				if(isset($attr['restriction_type']) && array_intersect($attr['restriction_type'], $valid_restriction_types))
+				if(array_intersect($attr['restriction_type'], $valid_restriction_types))
 					if(empty($_g['_s2member_res']['type']) || !in_array($_g['_s2member_res']['type'], $attr['restriction_type'], TRUE))
 						return '';
 			}


### PR DESCRIPTION
Resolves websharks/s2member#305.

@jaswsinc I've tested this and it seems to work as expected but would appreciate a code review:
- If `required_type=""` contains multiple values (e.g., `required_type="ccap|level"`), the `required_value=""` attribute is ignored.
- The new `required_value=""` attribute supports multiple values (e.g., `required_value="0|1|2"` or `required_value="ccap1|ccap2|ccap3"`)

Tested with these shortcodes:

```
[s2MOP required_type="ccap" required_value="free_gift"]This content required a Custom Capability called <code>free_gift</code>[/s2MOP]
```

```
[s2MOP required_type="level" required_value="0|1"]You were trying to access a Post that requires Level <code>0</code> or <code>1</code>[/s2MOP]
```
