### PR TITLE
Bug fix. Invalid Parameters to Stripe after tax calculation under certai...

### DIFF
--- a/s2member-pro/includes/classes/gateways/stripe/stripe-utilities.inc.php
+++ b/s2member-pro/includes/classes/gateways/stripe/stripe-utilities.inc.php
@@ -402,7 +402,7 @@ if(!class_exists('c_ws_plugin__s2member_pro_stripe_utilities'))
 					return (integer)$amount;
 
 				default: // In cents.
-					return (integer)number_format($amount * 100, 0);
+					return (integer)number_format($amount * 100, 0, '.', '');
 			}
 		}
 


### PR DESCRIPTION
Bug fix. Invalid Parameters to Stripe after tax calculation under certain scenarios. See: https://github.com/websharks/s2member/issues/425
